### PR TITLE
Ensure initial notification on cold boots is passed to new intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Instead the notifications go to the "system tray" application, and it automatica
 These automatic background notifications have several limited functionality:
 
 - They do not support the full range of options that are available to app generated "local notifications". e.g. `largeIcon` is not supported.
-  
+
   Please refer to the official [Firebase server reference](https://firebase.google.com/docs/cloud-messaging/http-server-ref#table2) to see what is supported.
 
 - When a user taps on an system tray generated notification the Android OS will actually re-launch your app's primary/launcher activity. If you're using stock React Native this effectively restarts your app.
@@ -331,7 +331,7 @@ We provide a similar implementation on Android using `NotificationsAndroid.getIn
 ```javascript
 import {NotificationsAndroid} from 'react-native-notifications';
 
-PendingNotifications.getInitialNotification()
+NotificationsAndroid.getInitialNotification()
   .then((notification) => {
   		console.log("Initial notification was:", notification || "N/A");
 	})
@@ -670,10 +670,10 @@ The [example app](https://github.com/wix/react-native-notifications/tree/master/
 	- `default` (default) - Displayes up to 4 actions (full UI).
 	- `minimal` - Displays up tp 2 actions (minimal UI).
 
-	
-#### Set application icon badges count (iOS only) 
 
-Set to specific number: 
+#### Set application icon badges count (iOS only)
+
+Set to specific number:
 ```javascript
 NotificationsIOS.setBadgesCount(2);
 ```

--- a/android/src/main/java/com/wix/reactnativenotifications/core/AppLaunchHelper.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/AppLaunchHelper.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import com.wix.reactnativenotifications.core.notifications.IntentExtras;
+import com.wix.reactnativenotifications.core.notifications.NotificationProps;
 
 public class AppLaunchHelper {
     private static final String TAG = AppLaunchHelper.class.getSimpleName();
@@ -23,8 +24,16 @@ public class AppLaunchHelper {
             // flags) as they do.
             final Intent helperIntent = appContext.getPackageManager().getLaunchIntentForPackage(appContext.getPackageName());
             final Intent intent = new Intent(appContext, Class.forName(helperIntent.getComponent().getClassName()));
+            final NotificationProps notification = InitialNotificationHolder.getInstance().get();
+
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
             intent.putExtra(IntentExtras.FCM_PREFIX, true);
+            if (notification != null) {
+                // If an initial notification has been set from a cold boot, we must pass on
+                // the notification to ensure it is accessible from subsequent getInitialNotification calls
+                intent.putExtras(notification.asBundle());
+            }
+
             return intent;
         } catch (ClassNotFoundException e) {
             // Note: this is an imaginary scenario cause we're asking for a class of our very own package.


### PR DESCRIPTION
Took a while to debug this, but tl;dr I've been unable to `getInitialNotification` to work from a cold boot (app completely closed - and push notification touched to open).

The following sequence on a cold boot was happening:

  * `setAsInitialNotification` triggered from `LocalNotification.java` correctly sets the push notification to `initialNotificationHolder`
      * data={"custom":"data"}, icon=@drawable/status_bar, largeIcon=@drawable/ic_launcher, 
  *  `onActivityCreated` of `RNNotificationsModule` is then triggered
      * The intent of this is now different to above because of regenerated intent in `getLaunchIntent` with lost extras (the initial notification is lost).
  *  `onNewActivity` of `NotificationDrawer.java` is triggered
      *   `if (!mAppLaunchHelper.isLaunchIntentOfNotification(intent)) {` returns true and is processed
          * `initialNotificationHolder` is _cleared_ 
      * `if (mAppLaunchHelper.isLaunchIntentOfBackgroundPushNotification(intent)) {` returns true and is processed
          * The now cleared notification is updated with the incorrect intent body of (with notification missing):
          * `{ NativeMap: {"google.":true,"data":{}} }`


This PR changes `getLaunchIntent` to ensure the initial notification is passed along in the intent to ensure it isn't lost. Now `getInitialNotification()` works perfectly - even from cold boot push notification touches, to allow things like initial navigation based on initial notification touches.